### PR TITLE
Added parallelStream() and setThreads() methods

### DIFF
--- a/src/main/java/pl/uj/edu/JImageStream/Runner.java
+++ b/src/main/java/pl/uj/edu/JImageStream/Runner.java
@@ -2,7 +2,11 @@ package pl.uj.edu.JImageStream;
 
 import pl.uj.edu.JImageStream.api.Filter;
 import pl.uj.edu.JImageStream.api.collectors.StreamableImageCollector;
-import pl.uj.edu.JImageStream.api.filters.*;
+import pl.uj.edu.JImageStream.api.filters.BlueFilter;
+import pl.uj.edu.JImageStream.api.filters.GreenFilter;
+import pl.uj.edu.JImageStream.api.filters.RedFilter;
+import pl.uj.edu.JImageStream.api.filters.SaltAndPepperFilter;
+import pl.uj.edu.JImageStream.api.filters.SepiaFilter;
 import pl.uj.edu.JImageStream.model.StreamableImage;
 import pl.uj.edu.JImageStream.api.ColorChannel;
 
@@ -25,35 +29,34 @@ public class Runner {
         streamableImage.stream().apply(new GreenFilter()).collect(new StreamableImageCollector()).save("jpg", "green.jpg");
 
 //      channel() test
-        streamableImage.stream().bounds(point -> true)
-                .channel(ColorChannel.BLUE, ColorChannel.RED).apply(new SepiaFilter())
-                .collect(new StreamableImageCollector()).save("jpg", "sepiaBlueRedChannel.jpg");
+        streamableImage.stream()
+                .bounds(point -> true)
+                .channel(ColorChannel.BLUE, ColorChannel.RED)
+                .apply(new SepiaFilter())
+                .collect(new StreamableImageCollector())
+                .save("jpg", "sepiaBlueRedChannel.jpg");
 
 
 
 //      parallelStream() test
-            streamableImage.parallelStream().bounds(point -> true)
-                    .apply(new GreenFilter())
-                    .collect(new StreamableImageCollector()).save("jpg", "parallelStream-green.jpg");
+        streamableImage.parallelStream()
+                .bounds(point -> true)
+                .apply(new GreenFilter())
+                .collect(new StreamableImageCollector())
+                .save("jpg", "parallelStream-green.jpg");
 
 
-        try {
-            streamableImage.parallelStream()
-                    .setThreads(50)
-                    .apply(new Filter() {
-                        @Override
-                        public void apply(int x, int y) {
-
-                        }
-                    })
-                    .setThreads(1)
-                    .apply(new SaltAndPepperFilter())
-                    .collect(new StreamableImageCollector())
-                    .save("jpg", "parallelTest.jpg");
-
-        } catch(Exception e){
-            e.printStackTrace();
-        }
+        streamableImage.parallelStream()
+                .setThreads(50)
+                .apply(new Filter() {
+                    @Override
+                    public void apply(int x, int y) {
+                    }
+                })
+                .setThreads(1)
+                .apply(new SaltAndPepperFilter())
+                .collect(new StreamableImageCollector())
+                .save("jpg", "parallelTest.jpg");
 
     }
 

--- a/src/main/java/pl/uj/edu/JImageStream/Runner.java
+++ b/src/main/java/pl/uj/edu/JImageStream/Runner.java
@@ -2,11 +2,7 @@ package pl.uj.edu.JImageStream;
 
 import pl.uj.edu.JImageStream.api.Filter;
 import pl.uj.edu.JImageStream.api.collectors.StreamableImageCollector;
-import pl.uj.edu.JImageStream.api.filters.BlueFilter;
-import pl.uj.edu.JImageStream.api.filters.GreenFilter;
-import pl.uj.edu.JImageStream.api.filters.RedFilter;
-import pl.uj.edu.JImageStream.api.filters.SaltAndPepperFilter;
-import pl.uj.edu.JImageStream.api.filters.SepiaFilter;
+import pl.uj.edu.JImageStream.api.filters.*;
 import pl.uj.edu.JImageStream.model.StreamableImage;
 import pl.uj.edu.JImageStream.api.ColorChannel;
 
@@ -28,31 +24,36 @@ public class Runner {
         streamableImage.stream().bounds(point -> true).apply(new GreenFilter()).collect(new StreamableImageCollector()).save("jpg", "green.jpg");
         streamableImage.stream().apply(new GreenFilter()).collect(new StreamableImageCollector()).save("jpg", "green.jpg");
 
-//        channel() test
+//      channel() test
         streamableImage.stream().bounds(point -> true)
                 .channel(ColorChannel.BLUE, ColorChannel.RED).apply(new SepiaFilter())
                 .collect(new StreamableImageCollector()).save("jpg", "sepiaBlueRedChannel.jpg");
 
 
-        long millis = System.currentTimeMillis();
-        try {
+
+//      parallelStream() test
             streamableImage.parallelStream().bounds(point -> true)
+                    .apply(new GreenFilter())
+                    .collect(new StreamableImageCollector()).save("jpg", "parallelStream-green.jpg");
+
+
+        try {
+            streamableImage.parallelStream()
+                    .setThreads(50)
                     .apply(new Filter() {
                         @Override
                         public void apply(int x, int y) {
-                            try {
-                                Thread.sleep(1);
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
+
                         }
                     })
-                    .collect(new StreamableImageCollector());
-        } catch (Exception e) {
-            System.out.println("kamil, if you see this, parallelStream doesn't work");
-        }
-        System.out.println(System.currentTimeMillis() - millis);
+                    .setThreads(1)
+                    .apply(new SaltAndPepperFilter())
+                    .collect(new StreamableImageCollector())
+                    .save("jpg", "parallelTest.jpg");
 
+        } catch(Exception e){
+            e.printStackTrace();
+        }
 
     }
 

--- a/src/main/java/pl/uj/edu/JImageStream/api/Filter.java
+++ b/src/main/java/pl/uj/edu/JImageStream/api/Filter.java
@@ -13,7 +13,7 @@ public abstract class Filter {
 
     void setSource(BufferedImage bufferedImage) {
         this.source = bufferedImage.copyData(null);
-        this.output= bufferedImage.copyData(null);
+        this.output = bufferedImage.copyData(null);
     }
 
     void setRestrictions(ColorChannel[] colorChannels) {

--- a/src/main/java/pl/uj/edu/JImageStream/api/ImageStream.java
+++ b/src/main/java/pl/uj/edu/JImageStream/api/ImageStream.java
@@ -5,6 +5,7 @@ import pl.uj.edu.JImageStream.api.collectors.Collector;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
+import java.util.EmptyStackException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -21,22 +22,40 @@ public class ImageStream {
     private List<ImageTransform> filters;
     private Predicate<Point> predicate;
     private ColorChannel[] colorChannels;
+    private int numberOfThreads;
+    private int defaultNumberOfThreads;
+    private boolean parallel;
+
 
     public ImageStream apply(Filter filter) {
-        // [kamil] todo support for ParallelBoundedImageTransform
-        filters.add(new BoundedImageTransform(imageCopy, predicate != null ? predicate : TRUE_PREDICATE, filter,
-                                                colorChannels != null ? colorChannels : ALL_CHANNELS));
+        if(parallel){
+            filters.add(new ParallelBoundedImageTransform(imageCopy, predicate != null ? predicate : TRUE_PREDICATE, filter,
+                    colorChannels != null ? colorChannels : ALL_CHANNELS, numberOfThreads));
+        }else {
+            filters.add(new BoundedImageTransform(imageCopy, predicate != null ? predicate : TRUE_PREDICATE, filter,
+                    colorChannels != null ? colorChannels : ALL_CHANNELS));
+        }
         predicate = null;
         colorChannels = null;
+        numberOfThreads = defaultNumberOfThreads;
         return this;
     }
 
-    public ImageStream(BufferedImage bufferedImage) {
+
+    public ImageStream(BufferedImage bufferedImage, boolean parallel) {
         ColorModel cm = bufferedImage.getColorModel();
         boolean isAlpha = cm.isAlphaPremultiplied();
-        this.imageCopy = new BufferedImage(cm, bufferedImage.copyData(null), isAlpha, null);
+        imageCopy = new BufferedImage(cm, bufferedImage.copyData(null), isAlpha, null);
         filters = new LinkedList<>();
+        this.parallel = parallel;
+        if(parallel){
+            defaultNumberOfThreads = Runtime.getRuntime().availableProcessors();
+        }else{
+            defaultNumberOfThreads = 1;
+        }
+        numberOfThreads = defaultNumberOfThreads;
     }
+
 
     public ImageStream bounds(Predicate<Point> predicate) {
         this.predicate = predicate;
@@ -45,6 +64,17 @@ public class ImageStream {
 
     public ImageStream channel(ColorChannel... colorChannels) {
         this.colorChannels = colorChannels;
+        return this;
+    }
+
+    public ImageStream setThreads(int numberOfThreads) throws Exception{
+        if(!parallel){
+            throw new UnsupportedOperationException("Only parallel streams can use multiple threads");
+        }
+        if(numberOfThreads < 1){
+            throw new Exception("Number of threads must be at least 1");
+        }
+        this.numberOfThreads = numberOfThreads;
         return this;
     }
 

--- a/src/main/java/pl/uj/edu/JImageStream/api/ParallelBoundedImageTransform.java
+++ b/src/main/java/pl/uj/edu/JImageStream/api/ParallelBoundedImageTransform.java
@@ -4,7 +4,6 @@ import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -34,7 +33,7 @@ public class ParallelBoundedImageTransform implements ImageTransform {
     @Override
     public void apply() {
         //todo set executors from stream
-        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+        ExecutorService executor = Executors.newFixedThreadPool(Math.min(numberOfThreads, width));
         filter.setSource(image);
         filter.setRestrictions(colorChannels);
 
@@ -52,7 +51,6 @@ public class ParallelBoundedImageTransform implements ImageTransform {
             executor.shutdownNow();
             filter.saveToImage(image);
         }
-
     }
 
     class PixelExecutor implements Runnable {

--- a/src/main/java/pl/uj/edu/JImageStream/model/StreamableImage.java
+++ b/src/main/java/pl/uj/edu/JImageStream/model/StreamableImage.java
@@ -36,17 +36,11 @@ public class StreamableImage {
 
 
     public ImageStream stream() {
-        return new ImageStream(bufferedImage);
+        return new ImageStream(bufferedImage, false);
     }
 
     public ImageStream parallelStream() {
-        throw new UnsupportedOperationException();
-//        return new ImageStream(bufferedImage, true);
+        return new ImageStream(bufferedImage, true);
     }
-
-
-//    public ParallelImageStream parallelIStream() {
-//        return new ParallelImageStream(bufferedImage);
-//    }
 
 }


### PR DESCRIPTION
parallelStream lets us use multiple threads

In ImageStream constructor, second argument determines whether it is parallel or not, and with that sets defaultNumberOrThreads (for parallelStream it is equal to equal to number of threads in CPU)
.setThreads(int) method is only available for parallelStream (with normal stream it causes UnsupportedOperationException), checking if int number is greater or equal 1