### PR TITLE
Added support for alpha channel.

### DIFF
--- a/jis-api/src/main/java/pl/edu/uj/JImageStream/api/core/Filter.java
+++ b/jis-api/src/main/java/pl/edu/uj/JImageStream/api/core/Filter.java
@@ -55,7 +55,7 @@ public abstract class Filter {
     protected Pixel getPixel(int x, int y) {
         //todo alpha support, investigate when and where alpha chanel is present
         int[] pixel = source.getPixel(x, y, (int[]) null);
-        return new Pixel(pixel[0], pixel[1], pixel[2], 255);
+        return new Pixel(pixel[0], pixel[1], pixel[2], pixel[3]);
     }
 
     protected int getSourceHeight(){

--- a/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
+++ b/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
@@ -15,7 +15,7 @@ public class StreamableImage {
 
     //todo extract to IOImageUtilsClass, maybe
     public StreamableImage(File file) throws IOException {
-        bufferedImage = Util.convert(ImageIO.read(file), BufferedImage.TYPE_INT_ARGB_PRE);
+        bufferedImage = Util.convert(ImageIO.read(file), BufferedImage.TYPE_INT_ARGB);
     }
 
     public StreamableImage(BufferedImage bufferedImage) {

--- a/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
+++ b/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
@@ -15,7 +15,7 @@ public class StreamableImage {
 
     //todo extract to IOImageUtilsClass, maybe
     public StreamableImage(File file) throws IOException {
-        bufferedImage = Util.convert(ImageIO.read(file), BufferedImage.TYPE_4BYTE_ABGR_PRE);
+        bufferedImage = Util.convert(ImageIO.read(file), BufferedImage.TYPE_INT_ARGB_PRE);
     }
 
     public StreamableImage(BufferedImage bufferedImage) {

--- a/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
+++ b/jis-api/src/main/java/pl/edu/uj/JImageStream/model/StreamableImage.java
@@ -1,6 +1,7 @@
 package pl.edu.uj.JImageStream.model;
 
 import pl.edu.uj.JImageStream.api.ImageStream;
+import pl.edu.uj.JImageStream.util.Util;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -14,7 +15,7 @@ public class StreamableImage {
 
     //todo extract to IOImageUtilsClass, maybe
     public StreamableImage(File file) throws IOException {
-        bufferedImage = ImageIO.read(file);
+        bufferedImage = Util.convert(ImageIO.read(file), BufferedImage.TYPE_4BYTE_ABGR_PRE);
     }
 
     public StreamableImage(BufferedImage bufferedImage) {

--- a/jis-api/src/main/java/pl/edu/uj/JImageStream/util/Util.java
+++ b/jis-api/src/main/java/pl/edu/uj/JImageStream/util/Util.java
@@ -1,0 +1,16 @@
+package pl.edu.uj.JImageStream.util;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class Util {
+
+    public static BufferedImage convert(BufferedImage src, int bufImgType) {
+        BufferedImage img = new BufferedImage(src.getWidth(), src.getHeight(), bufImgType);
+        Graphics2D g2d = img.createGraphics();
+        g2d.drawImage(src, 0, 0, null);
+        g2d.dispose();
+        return img;
+    }
+
+}


### PR DESCRIPTION
Now by default is used BufferedImage.TYPE_4BYTE_ABGR_PRE ColorModel in StreamableImage constructor when loading from File object.
Also was added Util class with convert method that converts BufferedImage with given ColorModel.